### PR TITLE
refactor: migrate to Apollo Server v4

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 lib
+coverage

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,1 +1,6 @@
-extends: '@zakodium/eslint-config/adonis'
+extends:
+  - zakodium/ts
+  - zakodium/unicorn
+  - zakodium/adonis-v5
+env:
+  node: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,40 +6,9 @@ on:
       - main
   pull_request:
 
-env:
-  NODE_VERSION: 16.x
-
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Install dependencies
-        run: npm install
-      - name: Run ESLint
-        run: npm run eslint
-      - name: Run Prettier
-        run: npm run prettier
-      - name: Check types
-        run: npm run check-types
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        run: npm install
-      - name: Run tests
-        run: npm run test-only
-      - name: Send coverage report to Codecov
-        uses: codecov/codecov-action@v2
+  nodejs:
+    # Documentation: https://github.com/zakodium/workflows#nodejs-ci
+    uses: zakodium/workflows/.github/workflows/nodejs.yml@nodejs-v1
+    with:
+      lint-check-types: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,33 +4,13 @@ on:
   push:
     branches:
       - main
-env:
-  NODE_VERSION: 16.x
 
 jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get package name
-        run: echo "PACKAGE_NAME=$(jq .name package.json | tr -d '"')" >> $GITHUB_ENV
-      - uses: GoogleCloudPlatform/release-please-action@v2
-        id: release
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          release-type: node
-          package-name: ${{ env.PACKAGE_NAME }}
-          bump-minor-pre-major: Yes
-      - uses: actions/checkout@v2
-        # These if statements ensure that a publication only occurs when a new release is created
-        if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm install
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOT_TOKEN }}
-        if: ${{ steps.release.outputs.release_created }}
+  release:
+    # Documentation: https://github.com/zakodium/workflows#release
+    uses: zakodium/workflows/.github/workflows/release.yml@release-v1
+    with:
+      npm: true
+    secrets:
+      github-token: ${{ secrets.BOT_TOKEN }}
+      npm-token: ${{ secrets.NPM_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ TODO
 
 ### Landing page
 
-To configure the landing page, use the `plugins` option in `config/apollo.ts`:
+To configure the default landing page, you can pass `apolloProductionLandingPageOptions`
+or `apolloLocalLandingPageOptions` to the config. Another possibility is to
+override the `plugins` config in `config/apollo.ts`.
 
 The default configuration is:
 
@@ -100,9 +102,11 @@ const plugins = [
   Env.get('NODE_ENV') === 'production'
     ? ApolloServerPluginLandingPageProductionDefault({
         footer: false,
+        apolloProductionLandingPageOptions,
       })
     : ApolloServerPluginLandingPageLocalDefault({
         footer: false,
+        apolloLocalLandingPageOptions,
       }),
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -58,9 +58,57 @@ Route.group(() => {
 }).middleware('someMiddleware');
 ```
 
+### Troubleshooting
+
+#### Error: Query root type must be provided
+
+Apollo requires a query root type to be defined in your schema.
+To fix this error, create a file `app/Schemas/SomeSchema.graphql` with at least
+a `Query` type.
+
+For example:
+
+```graphql
+type Query {
+  hello: String!
+}
+```
+
+#### BadRequestError: This operation has been blocked as a potential Cross-Site Request Forgery (CSRF)
+
+This error may happen if you try to access the GraphQL endpoint from a browser.
+Make sure `forceContentNegotiationTo` is not unconditionally set to `'application/json'` in `config/app.ts`.
+You can either disable this option or set it to a function that ignores the GraphQL route.
+
 ## Configuration
 
 TODO
+
+### Landing page
+
+To configure the landing page, use the `plugins` option in `config/apollo.ts`:
+
+The default configuration is:
+
+```ts
+import {
+  ApolloServerPluginLandingPageLocalDefault,
+  ApolloServerPluginLandingPageProductionDefault,
+} from '@apollo/server/plugin/landingPage/default';
+
+const plugins = [
+  Env.get('NODE_ENV') === 'production'
+    ? ApolloServerPluginLandingPageProductionDefault({
+        footer: false,
+      })
+    : ApolloServerPluginLandingPageLocalDefault({
+        footer: false,
+      }),
+];
+```
+
+See the [Apollo Graphql documentation](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages/) to
+learn how to customize or disable the landing page.
 
 ### Scalars
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ Apollo GraphQL server for AdonisJS 5.
 
 </h3>
 
-## Prerequisites
-
-This provider requires Adonis v5 and won't work with AdonisJS v4.
-
 ## Installation
 
 ```console
@@ -55,7 +51,7 @@ ApolloServer.applyMiddleware();
 // You can also call `applyMiddleware` inside a route group:
 Route.group(() => {
   ApolloServer.applyMiddleware();
-}).middleware('someMiddleware');
+}).middleware('auth');
 ```
 
 ### Troubleshooting
@@ -82,8 +78,6 @@ You can either disable this option or set it to a function that ignores the Grap
 
 ## Configuration
 
-TODO
-
 ### Landing page
 
 To configure the default landing page, you can pass `apolloProductionLandingPageOptions`
@@ -102,11 +96,11 @@ const plugins = [
   Env.get('NODE_ENV') === 'production'
     ? ApolloServerPluginLandingPageProductionDefault({
         footer: false,
-        apolloProductionLandingPageOptions,
+        ...apolloProductionLandingPageOptions,
       })
     : ApolloServerPluginLandingPageLocalDefault({
         footer: false,
-        apolloLocalLandingPageOptions,
+        ...apolloLocalLandingPageOptions,
       }),
 ];
 ```
@@ -127,10 +121,13 @@ scalar DateTime
 
 ### Uploads
 
-To enable support for GraphQL uploads:
+To enable support for inline multipart/form-data uploads using [graphql-upload](https://github.com/jaydenseric/graphql-upload):
 
-- Update the config of the bodyparser in `config/bodyparser.ts` by adding your GraphQL route (by default: `/graphql`) to the `multipart.processManually` array.
+- Set `enableUploads: true` in `config/apollo.ts`.
+- Update the config of the body parser in `config/bodyparser.ts` by adding your GraphQL route (by default: `/graphql`) to the `multipart.processManually` array.
 - Add the Upload scalar to your schema: `scalar Upload`.
+- Make sure your GraphQL upload client sends the `'Apollo-Require-Preflight'` header, otherwise Apollo will reject multipart requests
+  to prevent [CSRF attacks](https://www.apollographql.com/docs/apollo-server/security/cors/#graphql-upload).
 
 ## License
 

--- a/adonis-typings/container.ts
+++ b/adonis-typings/container.ts
@@ -1,9 +1,9 @@
 declare module '@ioc:Adonis/Core/Application' {
-  import type * as Errors from '@ioc:Zakodium/Apollo/Errors';
   import type { ApolloServer } from '@ioc:Zakodium/Apollo/Server';
 
   export interface ContainerBindings {
-    'Zakodium/Apollo/Errors': typeof Errors;
+    /* eslint-disable @typescript-eslint/naming-convention */
     'Zakodium/Apollo/Server': ApolloServer;
+    /* eslint-enable @typescript-eslint/naming-convention */
   }
 }

--- a/adonis-typings/errors.ts
+++ b/adonis-typings/errors.ts
@@ -1,9 +1,0 @@
-declare module '@ioc:Zakodium/Apollo/Errors' {
-  export {
-    AuthenticationError,
-    ForbiddenError,
-    UserInputError,
-    ApolloError,
-    toApolloError,
-  } from 'apollo-server-core';
-}

--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 
 /// <reference path="./container.ts" />
-/// <reference path="./errors.ts" />
 /// <reference path="./server.ts" />

--- a/adonis-typings/server.ts
+++ b/adonis-typings/server.ts
@@ -14,7 +14,7 @@ declare module '@ioc:Zakodium/Apollo/Server' {
     RouteMiddlewareHandler,
   } from '@ioc:Adonis/Core/Route';
 
-  export type Upload = Promise<FileUpload> | Array<Promise<FileUpload>>;
+  export type Upload = Promise<FileUpload>;
 
   class ApolloServer {
     public applyMiddleware(): void;

--- a/adonis-typings/server.ts
+++ b/adonis-typings/server.ts
@@ -4,6 +4,11 @@ declare module '@ioc:Zakodium/Apollo/Server' {
     BaseContext,
     // @ts-expect-error Package is compatible with both ESM and CJS.
   } from '@apollo/server';
+  import {
+    ApolloServerPluginLandingPageLocalDefaultOptions,
+    ApolloServerPluginLandingPageProductionDefaultOptions,
+    // @ts-expect-error Package is compatible with both ESM and CJS.
+  } from '@apollo/server/plugin/landingPage/default';
   import type { IExecutableSchemaDefinition } from '@graphql-tools/schema';
   import type { FileUpload } from 'graphql-upload/Upload.js';
   import type { UploadOptions } from 'graphql-upload/processRequest.js';
@@ -71,6 +76,16 @@ declare module '@ioc:Zakodium/Apollo/Server' {
       ApolloServerOptions<ContextType>,
       'schema' | 'resolvers' | 'typeDefs' | 'gateway'
     >;
+
+    /**
+     * Options passed to the Apollo Server production landing page plugin.
+     */
+    apolloProductionLandingPageOptions?: ApolloServerPluginLandingPageProductionDefaultOptions;
+
+    /**
+     * Options passed to the Apollo Server local landing page plugin.
+     */
+    apolloLocalLandingPageOptions?: ApolloServerPluginLandingPageLocalDefaultOptions;
 
     context?: ContextFn<ContextType>;
 

--- a/package.json
+++ b/package.json
@@ -59,14 +59,14 @@
     "@types/jest": "^29.4.0",
     "eslint": "^8.34.0",
     "eslint-config-zakodium": "^7.0.0",
-    "jest": "^29.4.2",
+    "jest": "^29.4.3",
     "prettier": "^2.8.4",
     "rimraf": "^4.1.2",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@apollo/server": "^4.3.3",
+    "@apollo/server": "^4.4.0",
     "@graphql-tools/load-files": "^6.6.1",
     "@graphql-tools/merge": "^8.3.18",
     "@graphql-tools/schema": "^9.0.16",

--- a/package.json
+++ b/package.json
@@ -54,25 +54,25 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
-    "@adonisjs/core": "^5.3.4",
-    "@adonisjs/logger": "^4.1.1",
-    "@types/jest": "^27.0.2",
-    "@zakodium/eslint-config": "^3.0.3",
-    "eslint": "^7.32.0",
-    "jest": "^27.2.2",
-    "prettier": "^2.4.1",
-    "rimraf": "^3.0.2",
-    "ts-jest": "^27.0.5",
-    "typescript": "^4.4.3"
+    "@adonisjs/core": "^5.9.0",
+    "@adonisjs/logger": "^4.1.5",
+    "@types/jest": "^29.4.0",
+    "eslint": "^8.34.0",
+    "eslint-config-zakodium": "^7.0.0",
+    "jest": "^29.4.2",
+    "prettier": "^2.8.4",
+    "rimraf": "^4.1.2",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@graphql-tools/load-files": "^6.4.0",
-    "@graphql-tools/merge": "^8.1.2",
-    "@graphql-tools/schema": "^8.2.0",
-    "@types/graphql-upload": "^8.0.7",
-    "apollo-server-core": "^3.3.0",
-    "graphql": "^15.6.0",
-    "graphql-scalars": "^1.10.1",
-    "graphql-upload": "^12.0.0"
+    "@apollo/server": "^4.3.3",
+    "@graphql-tools/load-files": "^6.6.1",
+    "@graphql-tools/merge": "^8.3.18",
+    "@graphql-tools/schema": "^9.0.16",
+    "@types/graphql-upload": "^15.0.2",
+    "graphql": "^16.6.0",
+    "graphql-scalars": "^1.20.1",
+    "graphql-upload": "^15.0.2"
   }
 }

--- a/providers/ApolloProvider.ts
+++ b/providers/ApolloProvider.ts
@@ -1,11 +1,3 @@
-import {
-  AuthenticationError,
-  ForbiddenError,
-  UserInputError,
-  ApolloError,
-  toApolloError,
-} from 'apollo-server-core';
-
 import { ApplicationContract } from '@ioc:Adonis/Core/Application';
 import { ApolloConfig } from '@ioc:Zakodium/Apollo/Server';
 
@@ -35,14 +27,6 @@ export default class ApolloProvider {
       this.loading = true;
       return new ApolloServer(this.app, apolloConfig, this.app.logger);
     });
-
-    this.app.container.singleton('Zakodium/Apollo/Errors', () => ({
-      AuthenticationError,
-      ForbiddenError,
-      UserInputError,
-      ApolloError,
-      toApolloError,
-    }));
   }
 
   public async boot(): Promise<void> {

--- a/src/ApolloServer.ts
+++ b/src/ApolloServer.ts
@@ -48,6 +48,8 @@ export default class ApolloServer<
       schemas: schemasPath = 'app/Schemas',
       resolvers: resolversPath = 'app/Resolvers',
       apolloServer = {},
+      apolloProductionLandingPageOptions,
+      apolloLocalLandingPageOptions,
       context = defaultContextFn as ContextFn<ContextType>,
       executableSchema = {},
       enableUploads = false,
@@ -94,10 +96,12 @@ export default class ApolloServer<
           ? // eslint-disable-next-line new-cap
             ApolloServerPluginLandingPageProductionDefault({
               footer: false,
+              ...apolloProductionLandingPageOptions,
             })
           : // eslint-disable-next-line new-cap
             ApolloServerPluginLandingPageLocalDefault({
               footer: false,
+              ...apolloLocalLandingPageOptions,
             }),
       ],
       ...apolloServer,

--- a/src/ApolloServer.ts
+++ b/src/ApolloServer.ts
@@ -1,38 +1,36 @@
-import { join } from 'path';
+import path from 'node:path';
 
-import { makeExecutableSchema } from '@graphql-tools/schema';
 import {
-  ApolloServerBase,
-  GraphQLOptions,
-  formatApolloErrors,
-  PluginDefinition,
-  ApolloServerPluginLandingPageGraphQLPlayground,
-} from 'apollo-server-core';
-import { processRequest, UploadOptions } from 'graphql-upload';
+  ApolloServer as ApolloServerBase,
+  type BaseContext,
+  // @ts-expect-error Package is compatible with both ESM and CJS.
+} from '@apollo/server';
+import {
+  ApolloServerPluginLandingPageLocalDefault,
+  ApolloServerPluginLandingPageProductionDefault,
+  // @ts-expect-error Package is compatible with both ESM and CJS.
+} from '@apollo/server/plugin/landingPage/default';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import processRequest, {
+  UploadOptions,
+} from 'graphql-upload/processRequest.js';
 
-import { ApplicationContract } from '@ioc:Adonis/Core/Application';
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
-import { LoggerContract } from '@ioc:Adonis/Core/Logger';
-import { ApolloConfig, ApolloBaseContext } from '@ioc:Zakodium/Apollo/Server';
+import type { ApplicationContract } from '@ioc:Adonis/Core/Application';
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+import type { LoggerContract } from '@ioc:Adonis/Core/Logger';
+import type { ApolloConfig, ContextFn } from '@ioc:Zakodium/Apollo/Server';
 
 import { graphqlAdonis } from './graphqlAdonis';
 import { getTypeDefsAndResolvers, printWarnings } from './schema';
 
-function makeContextFunction(
-  context?: (args: ApolloBaseContext) => unknown,
-): (args: ApolloBaseContext) => unknown {
-  if (typeof context === 'function') {
-    return function ctxFn(args: ApolloBaseContext) {
-      return context(args);
-    };
-  } else {
-    return function ctxFn(args: ApolloBaseContext) {
-      return args;
-    };
-  }
-}
+const defaultContextFn: ContextFn = () => ({});
 
-export default class ApolloServer extends ApolloServerBase {
+export default class ApolloServer<
+  ContextType extends BaseContext = BaseContext,
+> {
+  private $apolloServer: ApolloServerBase<ContextType>;
+  private $contextFunction: ContextFn<ContextType>;
+
   private $app: ApplicationContract;
 
   private $path: string;
@@ -42,17 +40,28 @@ export default class ApolloServer extends ApolloServerBase {
 
   public constructor(
     application: ApplicationContract,
-    config: ApolloConfig,
+    config: ApolloConfig<ContextType>,
     logger: LoggerContract,
   ) {
     const {
-      path = '/graphql',
+      path: graphQLPath = '/graphql',
       schemas: schemasPath = 'app/Schemas',
       resolvers: resolversPath = 'app/Resolvers',
       apolloServer = {},
+      context = defaultContextFn as ContextFn<ContextType>,
       executableSchema = {},
+      enableUploads = false,
+      uploadOptions,
     } = config;
-    let { context, ...rest } = apolloServer;
+
+    this.$app = application;
+
+    this.$path = graphQLPath;
+
+    this.$enableUploads = enableUploads;
+    this.$uploadOptions = uploadOptions;
+
+    this.$contextFunction = context;
 
     const schemasPaths: string[] = Array.isArray(schemasPath)
       ? schemasPath
@@ -62,9 +71,11 @@ export default class ApolloServer extends ApolloServerBase {
       : [resolversPath];
 
     const { typeDefs, resolvers, warnings } = getTypeDefsAndResolvers(
-      schemasPaths.map((schemaPath) => join(application.appRoot, schemaPath)),
+      schemasPaths.map((schemaPath) =>
+        path.join(application.appRoot, schemaPath),
+      ),
       resolversPaths.map((resolverPath) =>
-        join(application.appRoot, resolverPath),
+        path.join(application.appRoot, resolverPath),
       ),
     );
 
@@ -72,39 +83,25 @@ export default class ApolloServer extends ApolloServerBase {
       printWarnings(warnings, logger);
     }
 
-    const enablePlayground = config.enablePlayground ?? application.inDev;
-    const plugins: PluginDefinition[] = [];
-    if (enablePlayground) {
-      plugins.push(
-        ApolloServerPluginLandingPageGraphQLPlayground(
-          config.playgroundOptions,
-        ),
-      );
-    }
-
-    super({
+    this.$apolloServer = new ApolloServerBase<ContextType>({
       schema: makeExecutableSchema({
         ...executableSchema,
         typeDefs,
         resolvers,
       }),
-      context: makeContextFunction(context),
-      plugins,
-      ...rest,
+      plugins: [
+        this.$app.env.get('NODE_ENV') === 'production'
+          ? // eslint-disable-next-line new-cap
+            ApolloServerPluginLandingPageProductionDefault({
+              footer: false,
+            })
+          : // eslint-disable-next-line new-cap
+            ApolloServerPluginLandingPageLocalDefault({
+              footer: false,
+            }),
+      ],
+      ...apolloServer,
     });
-
-    this.$app = application;
-
-    this.$path = path;
-
-    this.$enableUploads = config.enableUploads ?? true;
-    this.$uploadOptions = config.uploadOptions;
-  }
-
-  private async createGraphQLServerOptions(
-    ctx: HttpContextContract,
-  ): Promise<GraphQLOptions> {
-    return super.graphQLServerOptions({ ctx });
   }
 
   public applyMiddleware(): void {
@@ -117,51 +114,30 @@ export default class ApolloServer extends ApolloServerBase {
   }
 
   public getGraphqlHandler() {
-    const landingPage = this.getLandingPage();
-
     return async (ctx: HttpContextContract) => {
-      let body: Record<string, unknown>;
-      if (ctx.request.method() === 'GET') {
-        body = ctx.request.qs();
-        // We cannot use ctx.request.accepts because the Adonis application may
-        // be configured to spoof the Accept header.
-        // Instead, consider that if the request doesn't have a "query" parameter,
-        // it is a direct request, and display the landing page.
-        if (landingPage && !body.query) {
-          ctx.response.header('Content-Type', 'text/html');
-          return landingPage.html;
-        }
-      } else {
-        body = ctx.request.body();
-      }
-
-      const options = await this.createGraphQLServerOptions(ctx);
-      return graphqlAdonis(options, ctx, body);
+      return graphqlAdonis(this.$apolloServer, this.$contextFunction, ctx);
     };
   }
 
   public getUploadsMiddleware() {
     return async (ctx: HttpContextContract, next: () => void) => {
       if (ctx.request.is(['multipart/form-data'])) {
-        try {
-          const processed = await processRequest(
-            ctx.request.request,
-            ctx.response.response,
-            this.$uploadOptions,
-          );
-          ctx.request.setInitialBody(processed);
-        } catch (error: any) {
-          if (error.status && error.expose) {
-            ctx.response.status(error.status);
-          }
-          // eslint-disable-next-line @typescript-eslint/no-throw-literal
-          throw formatApolloErrors([error], {
-            formatter: this.requestOptions.formatError,
-            debug: this.requestOptions.debug,
-          });
-        }
+        const processed = await processRequest(
+          ctx.request.request,
+          ctx.response.response,
+          this.$uploadOptions,
+        );
+        ctx.request.setInitialBody(processed);
       }
       return next();
     };
+  }
+
+  public start() {
+    return this.$apolloServer.start();
+  }
+
+  public stop() {
+    return this.$apolloServer.stop();
   }
 }

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,14 +1,17 @@
-import { join } from 'path';
+import path from 'node:path';
 
 import { FakeLogger } from '@adonisjs/logger';
 
 import { getTypeDefsAndResolvers, printWarnings } from '../schema';
 
 describe('getTypeDefsAndResolvers', () => {
-  const fixture = join(__dirname, '../../test-utils/fixtures/schema/test1');
+  const fixture = path.join(
+    __dirname,
+    '../../test-utils/fixtures/schema/test1',
+  );
   const result = getTypeDefsAndResolvers(
-    [join(fixture, 'schemas')],
-    [join(fixture, 'resolvers')],
+    [path.join(fixture, 'schemas')],
+    [path.join(fixture, 'resolvers')],
   );
   it('should merge schemas', () => {
     // Query, Mutation

--- a/src/graphqlAdonis.ts
+++ b/src/graphqlAdonis.ts
@@ -1,4 +1,5 @@
 import type { IncomingHttpHeaders } from 'node:http';
+import { Readable } from 'node:stream';
 
 // @ts-expect-error Package is compatible with both ESM and CJS.
 import { ApolloServer, type BaseContext, HeaderMap } from '@apollo/server';
@@ -37,12 +38,7 @@ export async function graphqlAdonis<
   if (body.kind === 'complete') {
     return ctx.response.send(body.string);
   } else {
-    // TODO: pipe the async iterator to the response
-    let bodyString = '';
-    for await (const chunk of body.asyncIterator) {
-      bodyString += chunk;
-    }
-    return ctx.response.send(bodyString);
+    return ctx.response.stream(Readable.from(body.asyncIterator));
   }
 }
 

--- a/src/graphqlAdonis.ts
+++ b/src/graphqlAdonis.ts
@@ -1,42 +1,57 @@
-import {
-  GraphQLOptions,
-  runHttpQuery,
-  convertNodeHttpToRequest,
-  HttpQueryError,
-} from 'apollo-server-core';
+import type { IncomingHttpHeaders } from 'node:http';
 
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+// @ts-expect-error Package is compatible with both ESM and CJS.
+import { ApolloServer, type BaseContext, HeaderMap } from '@apollo/server';
 
-export async function graphqlAdonis(
-  options: GraphQLOptions,
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+import type { ContextFn } from '@ioc:Zakodium/Apollo/Server';
+
+export async function graphqlAdonis<
+  ContextType extends BaseContext = BaseContext,
+>(
+  apolloServer: ApolloServer<ContextType>,
+  contextFunction: ContextFn<ContextType>,
   ctx: HttpContextContract,
-  body: Record<string, unknown>,
 ): Promise<void> {
-  try {
-    const { graphqlResponse, responseInit } = await runHttpQuery([ctx], {
-      method: 'POST',
-      options,
-      query: body,
-      request: convertNodeHttpToRequest(ctx.request.request),
+  apolloServer.assertStarted('AdonisJS');
+
+  const { body, headers, status } =
+    await apolloServer.executeHTTPGraphQLRequest({
+      httpGraphQLRequest: {
+        method: ctx.request.method(),
+        headers: transformHeaders(ctx.request.headers()),
+        body: ctx.request.body(),
+        search: ctx.request.parsedUrl.search ?? '',
+      },
+      context() {
+        return Promise.resolve(contextFunction({ ctx }));
+      },
     });
-    if (responseInit.headers) {
-      for (const [name, value] of Object.entries(responseInit.headers)) {
-        ctx.response.header(name, value);
-      }
-    }
-    ctx.response.status(responseInit.status || 200);
-    return ctx.response.send(graphqlResponse);
-  } catch (error) {
-    // TODO: use isHttpQueryError once available.
-    if (!(error instanceof HttpQueryError)) {
-      throw error;
-    }
-    if (error.headers) {
-      for (const [header, value] of Object.entries(error.headers)) {
-        ctx.response.header(header, value);
-      }
-    }
-    ctx.response.status(error.statusCode);
-    return ctx.response.send(error.message);
+
+  for (const [name, value] of headers) {
+    ctx.response.header(name, value);
   }
+
+  ctx.response.status(status ?? 200);
+
+  if (body.kind === 'complete') {
+    return ctx.response.send(body.string);
+  } else {
+    // TODO: pipe the async iterator to the response
+    let bodyString = '';
+    for await (const chunk of body.asyncIterator) {
+      bodyString += chunk;
+    }
+    return ctx.response.send(bodyString);
+  }
+}
+
+function transformHeaders(headers: IncomingHttpHeaders): HeaderMap {
+  const map = new HeaderMap();
+  for (const [name, value] of Object.entries(headers)) {
+    if (value) {
+      map.set(name, Array.isArray(value) ? value.join(', ') : value);
+    }
+  }
+  return map;
 }

--- a/src/scalarResolvers.ts
+++ b/src/scalarResolvers.ts
@@ -1,6 +1,6 @@
 import { GraphQLScalarType } from 'graphql';
 import { resolvers } from 'graphql-scalars';
-import { GraphQLUpload } from 'graphql-upload';
+import GraphQLUpload from 'graphql-upload/GraphQLUpload.js';
 
 export const scalarResolvers: Record<string, GraphQLScalarType> = {
   Upload: GraphQLUpload,

--- a/templates/apollo.txt
+++ b/templates/apollo.txt
@@ -1,6 +1,6 @@
-import { ApolloConfig, ApolloBaseContext } from '@ioc:Zakodium/Apollo/Server';
+import { ApolloConfig } from '@ioc:Zakodium/Apollo/Server';
 
-interface ApolloContext extends ApolloBaseContext {
+interface ApolloContext {
   // Define here what will be available in the GraphQL context
 }
 
@@ -8,10 +8,8 @@ const apolloConfig: ApolloConfig<ApolloContext> = {
   schemas: 'app/Schemas',
   resolvers: 'app/Resolvers',
   path: '/graphql',
-  apolloServer: {
-    context({ ctx }) {
-      return { ctx };
-    },
+  context({ ctx }) {
+    return {};
   },
   executableSchema: {
     inheritResolversFromInterfaces: true,

--- a/test-utils/fixtures/schema/test1/.eslintrc.yml
+++ b/test-utils/fixtures/schema/test1/.eslintrc.yml
@@ -1,0 +1,2 @@
+parserOptions:
+  sourceType: script

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "outDir": "./lib",
     "inlineSourceMap": true,
     "strict": true,


### PR DESCRIPTION
BREAKING CHANGE: Apollo Server was upgraded to version 4.
The `enableUploads` config option is now `false` by default.
The default GraphQL context doesn't include the `ctx` property anymore (it is now an empty object). The value is still passed to the context function.
The `context` config option should now be passed at the top level instead of the `apolloServer` object.
The `enablePlayground` and `playgroundOptions` config options were removed. You can now use Apollo Server plugins to configure the landing page.
ApolloError and friends were removed so we also removed the `Zakodium/Apollo/Errors` re-export path.
See https://www.apollographql.com/docs/apollo-server/migration/ for all details.

Closes: https://github.com/zakodium/adonis-apollo/issues/40
