### PR TITLE
feat: allow class fields resolvers and support inheritance from class prototype

### DIFF
--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -68,11 +68,11 @@ describe('getTypeDefsAndResolvers', () => {
     }
 
     for (const [resolver, expected] of [
-      ['value', 'test'],
+      ['value', 'testGrandParent-testParent-test'],
       ['parentOverride', 'testParent'],
       ['grandParentValue', 'testGrandParent'],
       ['parentValue', 'testParent'],
-      ['valueField', 'test'],
+      ['valueField', 'testGrandParent-testParent-test'],
       ['parentOverrideField', 'testParent'],
       ['grandParentValueField', 'testGrandParent'],
       ['parentValueField', 'testParent'],

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -2,7 +2,8 @@ import path from 'node:path';
 
 import { Ioc } from '@adonisjs/fold';
 import { FakeLogger } from '@adonisjs/logger';
-import { Kind } from 'graphql';
+import type { IFieldResolver } from '@graphql-tools/utils';
+import { type GraphQLResolveInfo, Kind } from 'graphql';
 
 import { getTypeDefsAndResolvers, printWarnings } from '../schema';
 
@@ -13,7 +14,7 @@ describe('getTypeDefsAndResolvers', () => {
     __dirname,
     '../../test-utils/fixtures/schema/test1',
   );
-  const result = getTypeDefsAndResolvers(
+  const { typeDefs, resolvers, warnings } = getTypeDefsAndResolvers(
     [path.join(fixture, 'schemas')],
     [path.join(fixture, 'resolvers')],
     testIoC,
@@ -21,35 +22,69 @@ describe('getTypeDefsAndResolvers', () => {
   it('should merge schemas', () => {
     // Query, Mutation
     expect(
-      result.typeDefs.definitions.filter(
+      typeDefs.definitions.filter(
         (def) => def.kind === Kind.OBJECT_TYPE_DEFINITION,
       ),
     ).toHaveLength(3);
 
     // URL, Bad, OtherBad
     expect(
-      result.typeDefs.definitions.filter(
+      typeDefs.definitions.filter(
         (def) => def.kind === Kind.SCALAR_TYPE_DEFINITION,
       ),
     ).toHaveLength(3);
   });
 
   it('should merge resolvers', () => {
-    expect(Object.keys(result.resolvers)).toStrictEqual([
+    expect(Object.keys(resolvers)).toStrictEqual([
       'Query',
       'Mutation',
       'D',
       'URL',
     ]);
+    expect(Object.keys(resolvers.Query)).toStrictEqual(['queryA', 'queryD']);
+    expect(Object.keys(resolvers.Mutation)).toStrictEqual(['mutationA']);
+  });
+
+  it('should walk the class prototype chain and support class fields', () => {
+    const DResolvers = resolvers.D as Record<
+      string,
+      IFieldResolver<unknown, unknown>
+    >;
+
+    expect(Object.keys(DResolvers)).toStrictEqual([
+      'value',
+      'parentOverride',
+      'grandParentValue',
+      'parentValue',
+      'valueField',
+      'parentOverrideField',
+      'grandParentValueField',
+      'parentValueField',
+    ]);
+
+    function callResolver(resolver: string) {
+      return DResolvers[resolver](null, {}, null, {} as GraphQLResolveInfo);
+    }
+
+    for (const [resolver, expected] of [
+      ['value', 'test'],
+      ['parentOverride', 'testParent'],
+      ['grandParentValue', 'testGrandParent'],
+      ['parentValue', 'testParent'],
+      ['valueField', 'test'],
+      ['parentOverrideField', 'testParent'],
+      ['grandParentValueField', 'testGrandParent'],
+      ['parentValueField', 'testParent'],
+    ]) {
+      expect(callResolver(resolver)).toBe(expected);
+    }
   });
 
   it('should warn about missing resolvers', () => {
-    expect(result.warnings.missingQuery).toStrictEqual(['queryB', 'queryC']);
-    expect(result.warnings.missingMutation).toStrictEqual([
-      'mutationB',
-      'mutationC',
-    ]);
-    expect(result.warnings.missingScalars).toStrictEqual(['Bad', 'OtherBad']);
+    expect(warnings.missingQuery).toStrictEqual(['queryB', 'queryC']);
+    expect(warnings.missingMutation).toStrictEqual(['mutationB', 'mutationC']);
+    expect(warnings.missingScalars).toStrictEqual(['Bad', 'OtherBad']);
   });
 });
 

--- a/test-utils/fixtures/schema/test1/resolvers/D.js
+++ b/test-utils/fixtures/schema/test1/resolvers/D.js
@@ -6,8 +6,43 @@ exports.Query = class Query {
   }
 };
 
-exports.DResolvers = class D {
+class DGrandParent {
+  value() {
+    return 'testGrandParent';
+  }
+  valueField = () => 'testGrandParent';
+
+  parentOverride() {
+    return 'testGrandParent';
+  }
+  parentOverrideField = () => 'testGrandParent';
+
+  grandParentValue() {
+    return 'testGrandParent';
+  }
+  grandParentValueField = () => 'testGrandParent';
+}
+
+class DParent extends DGrandParent {
+  value() {
+    return 'testParent';
+  }
+  valueField = () => 'testParent';
+
+  parentOverride() {
+    return 'testParent';
+  }
+  parentOverrideField = () => 'testParent';
+
+  parentValue() {
+    return 'testParent';
+  }
+  parentValueField = () => 'testParent';
+}
+
+exports.DResolvers = class D extends DParent {
   value() {
     return 'test';
   }
+  valueField = () => 'test';
 };

--- a/test-utils/fixtures/schema/test1/resolvers/D.js
+++ b/test-utils/fixtures/schema/test1/resolvers/D.js
@@ -41,8 +41,12 @@ class DParent extends DGrandParent {
 }
 
 exports.DResolvers = class D extends DParent {
+  #internalValue = 'test';
+
   value() {
-    return 'test';
+    return this.valueField();
   }
-  valueField = () => 'test';
+  valueField = () => {
+    return `${super.grandParentValue()}-${this.parentValueField()}-${this.#internalValue}`;
+  };
 };


### PR DESCRIPTION
Walk the prototype chain until we reach null or Object.prototype (which is ignored).

Closes: https://github.com/zakodium/adonis-apollo/issues/59
